### PR TITLE
[TECH] Ajouter un proxy_pass sur le healthcheck de l'API

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -42,19 +42,26 @@ server {
   location /api/token {
     proxy_pass https://<%= ENV["PIX_API_HOSTNAME"] %>/api/application/token;
   }
-  
+
   #
   # Pole Emploi API
   #
   location /pole-emploi {
     proxy_pass https://<%= ENV["PIX_API_HOSTNAME"] %>/api/pole-emploi;
   }
-  
+
   #
   # LSU API
   #
   location /organizations {
     proxy_pass https://<%= ENV["PIX_API_HOSTNAME"] %>/api/organizations;
+  }
+
+  #
+  # Healthcheck
+  #
+  location /healthcheck {
+    proxy_pass https://<%= ENV["PIX_API_HOSTNAME"] %>/api/healthcheck/db;
   }
 
   add_header X-Content-Type-Options "nosniff";


### PR DESCRIPTION
## :unicorn: Problème
Il n'existe pas aujourd'hui d'endpoint healthcheck permettant de vérifier que l'application est disponible.

## :robot: Proposition
Ajouter un proxy_pass sur le healthcheck de l'API