### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pix Gravitee APIM deployment
+# Pix nginx-based APIM
 
 Ce dépot contient le code poussé sur Scalingo pour déployer l'instance APIM de Pix.
 

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Variables d'environement :
  * Choisir la version de nginx `NGINX_VERSION=1.8.0`
  * Définir le host cible `PIX_API_HOSTNAME=api.recette.pix.fr`
 
-Le fichier à configurer est le fichier `nginx.conf.erb`
+Le fichier à configurer est le fichier `servers.conf.erb`


### PR DESCRIPTION
## :christmas_tree: Problème

Le README actuel cite Gravitee et un nom de fichier de conf qui a changé.

## :gift: Proposition

Citer nginx à la place de Gravitee et indiquer le nom du fichier de conf actuellement utilisé.

## :socks: Remarques

RAS

## :santa: Pour tester

Il s'agit uniquement de modifications sur la documentation.
