### PR TITLE
[FEATURE] Ajoute les endpoints `parcoursup` à la passerelle.

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -64,6 +64,13 @@ server {
     proxy_pass https://<%= ENV["PIX_API_HOSTNAME"] %>/api/healthcheck/db;
   }
 
+  #
+  # Parcoursup
+  #
+  location /parcoursup/ {
+    proxy_pass https://<%= ENV["PIX_API_HOSTNAME"] %>/api/parcoursup/;
+  }
+
   add_header X-Content-Type-Options "nosniff";
   add_header X-Frame-Options "SAMEORIGIN";
   add_header X-XSS-Protection 1;


### PR DESCRIPTION
## :christmas_tree: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

On souhaite exposer les endpoints d'API spécifique à Parcoursup derrière la gateway d'API.

## :gift: Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

Ajouter une directive `location` matchant `/parcoursup/`.

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Testé en local avec un nginx dans un docker.
