### PR TITLE
[TECH] Modification de l'url d'acces a l'API Parcoursup (PIX-16090).

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -76,7 +76,7 @@ server {
     proxy_pass https://<%= ENV["PIX_API_HOSTNAME"] %>/parcoursup/documentation;
   }
   location /parcoursup/ {
-    proxy_pass https://<%= ENV["PIX_API_HOSTNAME"] %>/api/parcoursup/;
+    proxy_pass https://<%= ENV["PIX_API_HOSTNAME"] %>/api/application/parcoursup/;
   }
 
   add_header X-Content-Type-Options "nosniff";


### PR DESCRIPTION
## :pancakes: Problème

Suite à une revue avec Team Acces + Team Secu, pour harmoniser et mieux gérer finement les applications de l’API Pix, il manque un /application au niveau de la route /api/parcoursup/certification/search

## :bacon: Proposition

Changer la configuration pour migrer vers la nouvelle URL
Le but est de faire fonctionner la nouvelle URL qui est `/api/application/parcoursup/certification/search`

## 🧃 Remarques

~A merger apres https://github.com/1024pix/pix/pull/11112~
C'est mergé !

## :yum: Pour tester

Je ne sais pas comment tester le nginx de l'APIM en local ou RA
