### PR TITLE
[FEATURE] Regroupement des endpoints Parcoursup

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -72,9 +72,6 @@ server {
   #
   # Parcoursup
   #
-  location /parcoursup/documentation {
-    proxy_pass https://<%= ENV["PIX_API_HOSTNAME"] %>/parcoursup/documentation;
-  }
   location /parcoursup/ {
     proxy_pass https://<%= ENV["PIX_API_HOSTNAME"] %>/api/application/parcoursup/;
   }


### PR DESCRIPTION
## :pancakes: Problème

Maintenir application et documentation sous des endpoints separes n'était pas idéal. Au niveau APIM cela faisait aussi deux configurations pour la meme application.

## :bacon: Proposition

Nous avons regroupe au niveau de l'application la documentation avec les endpoints qui servent la données.
La configuration spécifique APIM pour la documentation n'est plus nécessaire.

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

Verifier que la configuration actuelle est compatible pour servir l'url : `/api/application/parcoursup/swagger.json` et `/api/application/parcoursup/documentation`
