### PR TITLE
[TECH] Parcoursup : configuration compatible API manager pour exposer la documentation (PIX-16304).

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -76,6 +76,13 @@ server {
     proxy_pass https://<%= ENV["PIX_API_HOSTNAME"] %>/api/application/parcoursup/;
   }
 
+  #
+  # Open API documentation
+  #
+  location ~ ^/documentation/(.*)?$  {
+    proxy_pass https://<%= ENV["PIX_API_HOSTNAME"] %>/documentation/$1;
+  }
+
   add_header X-Content-Type-Options "nosniff";
   add_header X-Frame-Options "SAMEORIGIN";
   add_header X-XSS-Protection 1;


### PR DESCRIPTION
## :pancakes: Problème

Certains assets ne sont pas accessible via l’APIM

## :bacon: Proposition

Valide avec les captains, a partir d’un reverse proxy en local avec Docker

* Regrouper les assets Swagger sous /documenttion
* Les rendre accessible via le reverse proxy via un identifiant applicatif

## 🧃 Remarques

## :yum: Pour tester

Tester avec un reverse proxy local, tous les /documentation seront rediriges vers /documentation cote API Pix

